### PR TITLE
fix: More robust handling of ISO backend URL and add diagnostics

### DIFF
--- a/src/lib/testing/config/backend-config.ts
+++ b/src/lib/testing/config/backend-config.ts
@@ -5,7 +5,7 @@ import { BackendConfig } from "../types/backend-types";
  * Configuration for the backend service
  */
 export const BACKEND_CONFIG: BackendConfig = {
-  apiUrl: import.meta.env.VITE_ISO_BACKEND_URL || null,
+  apiUrl: (import.meta.env.VITE_ISO_BACKEND_URL && import.meta.env.VITE_ISO_BACKEND_URL.trim() !== '') ? import.meta.env.VITE_ISO_BACKEND_URL.trim() : null,
   endpoints: {
     generateIso: "/api/iso/generate",
     status: "/api/iso/status",

--- a/src/lib/testing/services/api-client.ts
+++ b/src/lib/testing/services/api-client.ts
@@ -25,12 +25,17 @@ export class ApiClient {
    * Check if the backend API is available
    */
   async checkApiAvailability(): Promise<boolean> {
+    console.log('[ApiClient] checkApiAvailability called. apiUrl:', this.config.apiUrl, 'Status endpoint path:', this.config.endpoints?.status);
     if (!this.config.apiUrl) {
       console.warn("Backend API URL is not configured. Skipping availability check.");
       return Promise.resolve(false);
     }
     try {
-      const response = await fetch(`${this.config.apiUrl}/health`, {
+      // Using this.config.endpoints.status for health check as per instruction,
+      // though typically /health is more common for a general health check.
+      const healthCheckUrl = `${this.config.apiUrl}${this.config.endpoints.status}`;
+      console.log('[ApiClient] Attempting to fetch health check from:', healthCheckUrl);
+      const response = await fetch(healthCheckUrl, {
         method: 'GET',
         headers: { 'Content-Type': 'application/json' }
       });


### PR DESCRIPTION
This commit includes targeted fixes to prevent calls to 'localhost:3000' when the VITE_ISO_BACKEND_URL is not set, and adds logging to help diagnose issues on deployment.

Changes:
- In `src/lib/testing/config/backend-config.ts`:
  - I made the logic for setting `apiUrl` more robust. It now explicitly sets `apiUrl` to `null` if `VITE_ISO_BACKEND_URL` is undefined, null, an empty string, or contains only whitespace.

- In `src/lib/testing/services/api-client.ts`:
  - I added `console.log` statements in the `checkApiAvailability` method to output the `apiUrl` being used and the full URL being fetched for the health check. This is for diagnostic purposes on Netlify.
  - I corrected the health check URL to use the configured `endpoints.status` path.