### PR TITLE
fix: Correct auth listener unsubscribe and remove temp logs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,7 +46,7 @@ const App = () => {
     );
 
     return () => {
-      authListener?.unsubscribe();
+      authListener?.subscription?.unsubscribe();
     };
   }, [navigate]);
 

--- a/src/lib/testing/services/api-client.ts
+++ b/src/lib/testing/services/api-client.ts
@@ -25,7 +25,6 @@ export class ApiClient {
    * Check if the backend API is available
    */
   async checkApiAvailability(): Promise<boolean> {
-    console.log('[ApiClient] checkApiAvailability called. apiUrl:', this.config.apiUrl, 'Status endpoint path:', this.config.endpoints?.status);
     if (!this.config.apiUrl) {
       console.warn("Backend API URL is not configured. Skipping availability check.");
       return Promise.resolve(false);
@@ -34,7 +33,6 @@ export class ApiClient {
       // Using this.config.endpoints.status for health check as per instruction,
       // though typically /health is more common for a general health check.
       const healthCheckUrl = `${this.config.apiUrl}${this.config.endpoints.status}`;
-      console.log('[ApiClient] Attempting to fetch health check from:', healthCheckUrl);
       const response = await fetch(healthCheckUrl, {
         method: 'GET',
         headers: { 'Content-Type': 'application/json' }


### PR DESCRIPTION
This commit includes two main changes:

1.  **Corrected Supabase Auth Listener Unsubscribe:** In `src/App.tsx`, the cleanup function for the `onAuthStateChange` useEffect hook was changed from `authListener?.unsubscribe()` to `authListener?.subscription?.unsubscribe()`. This is the correct way to unsubscribe from the auth state change listener and resolves a "TypeError: r.unsubscribe is not a function" runtime error that was causing a blank page on deployment.

2.  **Removed Temporary Console Logs:** Removed diagnostic `console.log` statements from the `checkApiAvailability` method in `src/lib/testing/services/api-client.ts`. These logs were added for debugging an issue with `apiUrl` which has since been resolved.