### PR TITLE
fix: Correct syntax error in Configurations.tsx

### DIFF
--- a/src/pages/Configurations.tsx
+++ b/src/pages/Configurations.tsx
@@ -269,11 +269,6 @@ const Configurations: React.FC = () => {
       </div>
     );
   };
-          ))}
-        </div>
-      )}
-    </div>
-  );
-};
+// Extraneous lines removed from here
 
 export default Configurations;


### PR DESCRIPTION
Removed extraneous JSX closing tags from the end of the `src/pages/Configurations.tsx` file. These misplaced tags were causing an "Unexpected ')'" error during the Vite build process.