### PR TITLE
fix: Ensure button content visibility and remove all tooltips

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -13,10 +13,10 @@ const buttonVariants = cva(
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:
-          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+          "border border-input bg-background text-foreground hover:bg-accent hover:text-accent-foreground",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
+        ghost: "text-foreground hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -10,12 +10,13 @@ import { Input } from "@/components/ui/input"
 import { Separator } from "@/components/ui/separator"
 import { Sheet, SheetContent } from "@/components/ui/sheet"
 import { Skeleton } from "@/components/ui/skeleton"
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip"
+// Removed Tooltip related imports:
+// import {
+//   Tooltip,
+//   TooltipContent,
+//   TooltipProvider,
+//   TooltipTrigger,
+// } from "@/components/ui/tooltip"
 
 const SIDEBAR_COOKIE_NAME = "sidebar:state"
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
@@ -129,7 +130,7 @@ const SidebarProvider = React.forwardRef<
 
     return (
       <SidebarContext.Provider value={contextValue}>
-        <TooltipProvider delayDuration={0}>
+        {/* <TooltipProvider delayDuration={0}> */} {/* TooltipProvider removed */}
           <div
             style={
               {
@@ -147,7 +148,7 @@ const SidebarProvider = React.forwardRef<
           >
             {children}
           </div>
-        </TooltipProvider>
+        {/* </TooltipProvider> */} {/* TooltipProvider removed */}
       </SidebarContext.Provider>
     )
   }
@@ -565,27 +566,28 @@ const SidebarMenuButton = React.forwardRef<
       />
     )
 
-    if (!tooltip) {
-      return button
-    }
+    // Tooltip logic removed, return button directly
+    // if (!tooltip) {
+    return button
+    // }
 
-    if (typeof tooltip === "string") {
-      tooltip = {
-        children: tooltip,
-      }
-    }
+    // if (typeof tooltip === "string") {
+    //   tooltip = {
+    //     children: tooltip,
+    //   }
+    // }
 
-    return (
-      <Tooltip>
-        <TooltipTrigger asChild>{button}</TooltipTrigger>
-        <TooltipContent
-          side="right"
-          align="center"
-          hidden={state !== "collapsed" || isMobile}
-          {...tooltip}
-        />
-      </Tooltip>
-    )
+    // return (
+    //   <Tooltip>
+    //     <TooltipTrigger asChild>{button}</TooltipTrigger>
+    //     <TooltipContent
+    //       side="right"
+    //       align="center"
+    //       hidden={state !== "collapsed" || isMobile}
+    //       {...tooltip}
+    //     />
+    //   </Tooltip>
+    // )
   }
 )
 SidebarMenuButton.displayName = "SidebarMenuButton"

--- a/src/pages/Configurations.tsx
+++ b/src/pages/Configurations.tsx
@@ -189,7 +189,7 @@ const Configurations: React.FC = () => {
                     <HardDrive className="mr-2 h-5 w-5 text-blue-500" />
                     <CardTitle>{config.name}</CardTitle>
                   </div>
-                  <Button variant="ghost" size="icon">
+                  <Button variant="ghost" size="icon" className="text-muted-foreground">
                     <Settings className="h-4 w-4" />
                   </Button>
                 </div>


### PR DESCRIPTION
This commit addresses two main issues:
1.  Ensures that text and icons within certain button variants are visible by default, fixing a bug where they were invisible until hovered.
2.  Removes all `shadcn/ui` tooltip functionality from the application as per your request.

Detailed changes:

-   **Button Visibility Fixes:**
    -   In `src/components/ui/button.tsx`:
        - Added `text-foreground` to the default styles for `outline`
          and `ghost` button variants to provide a visible default text/icon color.
    -   In `src/pages/Configurations.tsx`:
        - Added `className="text-muted-foreground"` to the Settings icon
          button on configuration cards to ensure its visibility.
    -   Buttons in `Header.tsx` were reviewed; their existing `text-white`
        class on a dark background should ensure visibility, benefiting
        from the base variant fixes.

-   **Tooltip Removal:**
    -   Verified that `TooltipProvider` was removed from `App.tsx`.
    -   Removed `TooltipProvider`, `Tooltip`, `TooltipTrigger`, and
        `TooltipContent` components and their imports from
        `src/components/ui/sidebar.tsx`.
    -   Confirmed previous tooltip removals from other components like
        `src/components/BuildStep.tsx` and cleaned up any unused
        tooltip imports (e.g., in `src/components/LFSBuilder.tsx`).