### PR TITLE
fix: Enable TypeScript compilation for GitHub Actions ISO script

### DIFF
--- a/.github/workflows/iso-generator.yml
+++ b/.github/workflows/iso-generator.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Install Dependencies
         run: npm install
 
+      - name: Compile TypeScript libs for script
+        run: npx tsc -p tsconfig.scripts.json
+
       - name: Generate ISO
         run: |
           mkdir -p ./generated_iso # Ensure output directory exists

--- a/scripts/generate-iso-action.mjs
+++ b/scripts/generate-iso-action.mjs
@@ -5,8 +5,8 @@ import path from 'path';
 // If these are TypeScript files, the GitHub Action would need a TS execution step (e.g., ts-node)
 // or they need to be pre-compiled to JS.
 // For Node.js ESM, explicit file extensions are often required for relative imports.
-import { IsoGenerator } from '../src/lib/testing/iso-generator.js';
-import { DockerService } from '../src/lib/testing/docker-service.js';
+import { IsoGenerator } from '../dist_lib/lib/testing/iso-generator.js';
+import { DockerService } from '../dist_lib/lib/testing/docker-service.js';
 
 async function main() {
   console.log('Starting ISO generation script (ESM)...');

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -1,0 +1,35 @@
+{
+  "extends": "./tsconfig.json", // Inherit baseUrl, paths, etc.
+  "compilerOptions": {
+    "outDir": "./dist_lib",           // Output directory for compiled JS
+    "rootDir": "./src",               // Specify root to maintain folder structure in outDir
+    "module": "ESNext",             // Output ES Modules
+    "moduleResolution": "NodeNext",   // Or "Node", "Bundler". NodeNext is modern.
+    "target": "ES2022",             // Modern Node versions support this
+    "declaration": false,             // No .d.ts files needed for script execution
+    "skipLibCheck": true,
+    // Ensure settings from base tsconfig.json that might conflict are overridden or managed
+    // For example, if the base tsconfig.json had "noEmit": true, we'd need to override it.
+    // The current base tsconfig.json does not have "noEmit": true.
+    "noEmit": false, // Explicitly ensure emit is on
+    // The following are already in the base tsconfig.json but are good to be aware of for script compilation
+    "allowJs": true,
+    "esModuleInterop": true, // Good for interop with CommonJS if any lib uses it
+    "resolveJsonModule": true // If your scripts import JSON
+  },
+  "include": [
+    "src/lib/**/*.ts" // Compile only .ts files from src/lib
+    // Add other specific paths if your script depends on more, e.g., "src/scripts_utils/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "**/*.test.ts", // Exclude test files
+    "**/*.spec.ts",
+    "src/vite-env.d.ts", // Exclude Vite specific env types
+    "src/main.tsx",      // Exclude frontend entry point
+    "src/App.tsx",       // Exclude main App component
+    "src/pages/**/*.tsx",// Exclude page components
+    "src/components/**/*.tsx" // Exclude UI components
+    // Add other frontend specific paths if they cause issues or are not needed by the script
+  ]
+}


### PR DESCRIPTION
This commit resolves an ERR_MODULE_NOT_FOUND error in the GitHub Actions workflow for ISO generation. The error occurred because the Node.js script was trying to import TypeScript files directly.

Changes include:

1.  **`tsconfig.scripts.json` Added:**
    - Created a new `tsconfig.scripts.json` file specifically for compiling TypeScript files from `src/lib/` into JavaScript (ESM) in a `./dist_lib` output directory. This configuration ensures that only necessary library files are compiled and are suitable for use in a Node.js environment.

2.  **GitHub Actions Workflow Updated (`.github/workflows/iso-generator.yml`):**
    - Added a new step "Compile TypeScript libs for script" before the script execution step. This new step runs `npx tsc -p tsconfig.scripts.json` to compile the required TypeScript files into the `dist_lib/` directory.

3.  **ISO Generation Script Updated (`scripts/generate-iso-action.mjs`):**
    - Modified the import paths for `IsoGenerator` and `DockerService` to point to the compiled JavaScript files within the `dist_lib/` directory (e.g., `../dist_lib/lib/testing/iso-generator.js`).

These changes ensure that the GitHub Action workflow first compiles the necessary TypeScript code to JavaScript, which can then be correctly imported and executed by the Node.js script, resolving the module not found errors.