### PR TITLE
fix: Remove MainNavigation imports from page components

### DIFF
--- a/src/pages/BuildHistoryPage.tsx
+++ b/src/pages/BuildHistoryPage.tsx
@@ -7,7 +7,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import { LFSBuildConfig, getBuildConfigurations } from '@/lib/supabase/configs';
 import { LFSBuildRecord } from '@/lib/supabase/types';
 import { getAllUserBuilds } from '@/lib/supabase/builds';
-import MainNavigation from '@/components/MainNavigation'; // Assuming MainNavigation is standard layout
+// Removed: import MainNavigation from '@/components/MainNavigation';
 import { ExternalLink, Eye } from 'lucide-react'; // Icons
 import type { Session } from '@supabase/supabase-js'; // Import Session type
 
@@ -59,16 +59,16 @@ const BuildHistoryPage: React.FC<BuildHistoryPageProps> = ({ session }) => { // 
   if (isLoading) {
     return (
       <div className="flex flex-col min-h-screen">
-        <MainNavigation />
-        <div className="container mx-auto py-8 text-center">Loading build history...</div>
+        {/* <MainNavigation /> Removed */}
+        <div className="container mx-auto py-8 text-center pt-8 md:pt-12">Loading build history...</div> {/* Added padding top */}
       </div>
     );
   }
 
   return (
     <div className="flex flex-col min-h-screen">
-      <MainNavigation />
-      <div className="container mx-auto py-8">
+      {/* <MainNavigation /> Removed */}
+      <div className="container mx-auto py-8 pt-8 md:pt-12"> {/* Added padding top */}
         <div className="flex justify-between items-center mb-6">
           <h1 className="text-3xl font-bold">Build History</h1>
           {/* Add any controls like refresh if needed */}

--- a/src/pages/IsoManagement.tsx
+++ b/src/pages/IsoManagement.tsx
@@ -1,6 +1,6 @@
 
 import React, { useState, useEffect } from "react";
-import MainNavigation from "../components/MainNavigation";
+// Removed: import MainNavigation from "../components/MainNavigation";
 import DockerMonitor from "../components/DockerMonitor";
 import { DockerService } from "@/lib/testing/docker-service";
 import { useToast } from "@/components/ui/use-toast";
@@ -54,9 +54,9 @@ const IsoManagementPage: React.FC<IsoManagementPageProps> = ({ session }) => {
   
   return (
     <div className="flex flex-col min-h-screen">
-      <MainNavigation />
+      {/* <MainNavigation /> Removed */}
       
-      <div className="container mx-auto px-4 py-6">
+      <div className="container mx-auto px-4 py-6 pt-8 md:pt-12"> {/* Added padding top */}
         {session?.user && <p className="text-sm text-gray-600 mb-1">User: {session.user.email}</p>}
         <HeaderSection 
           showDockerMonitor={showDockerMonitor}

--- a/src/pages/Testing.tsx
+++ b/src/pages/Testing.tsx
@@ -1,6 +1,6 @@
 
 import React, { useState } from "react";
-import MainNavigation from "../components/MainNavigation";
+// Removed: import MainNavigation from "../components/MainNavigation";
 import TestRunner from "../components/TestRunner";
 import DockerSetup from "../components/DockerSetup";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -22,9 +22,9 @@ const Testing: React.FC<TestingProps> = ({ session }) => {
 
   return (
     <div className="flex flex-col min-h-screen">
-      <MainNavigation />
+      {/* <MainNavigation /> Removed */}
       
-      <div className="container mx-auto px-4 py-6">
+      <div className="container mx-auto px-4 py-6 pt-8 md:pt-12"> {/* Added padding top to compensate for removed MainNavigation height */}
         <h1 className="text-3xl font-bold mb-6">LFS Testing & ISO Generation</h1>
         {session?.user && <p className="text-sm text-gray-600 mb-4">User: {session.user.email}</p>}
         


### PR DESCRIPTION
Removed import statements and usage of the deleted `MainNavigation` component from the following page files to resolve build errors:
- `src/pages/Testing.tsx`
- `src/pages/IsoManagement.tsx`
- `src/pages/BuildHistoryPage.tsx`

Added temporary top padding to these pages to maintain visual layout after the removal of the navigation component. `src/pages/Index.tsx` was confirmed to not have this import.

This change is part of the effort to consolidate the main navigation into the `Header.tsx` component and fixes a "Could not resolve" build error caused by referencing the deleted `MainNavigation` file.