### PR TITLE
fix: Correct syntax error in Header.tsx causing build failure

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -67,6 +67,7 @@ const Header: React.FC<HeaderProps> = ({
   };
 
   return (
+    <>
     <header className="bg-background text-foreground py-4"> {/* Use CSS variables */}
       <div className="container mx-auto px-4 flex justify-between items-center">
         <div className="flex items-center space-x-2">
@@ -214,7 +215,7 @@ const Header: React.FC<HeaderProps> = ({
         </DialogFooter>
       </DialogContent>
     </Dialog>
-  </>
+    </>
   );
 };
 


### PR DESCRIPTION
Addresses a build error "Expected ')' but found 'open'" in Header.tsx. The fix ensures that multiple top-level JSX elements (the `<header>` and the `<Dialog>` for the Settings modal) are correctly wrapped in a single React Fragment (`<>...</>`) in the component's return statement.